### PR TITLE
Add private_ip spaces follow rfc1918

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,13 @@ server {
     root /app/public;
     client_max_body_size 200m;
 
+    # Follow rfc1918: https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces
+    set_real_ip_from  10.0.0.0/8;
+    set_real_ip_from  192.168.0.0/16;
+    set_real_ip_from  172.16.0.0/12;
+    real_ip_header    X-Forwarded-For;
+    real_ip_recursive on;
+
     location / {
         try_files $uri /index.php$is_args$args;
     }


### PR DESCRIPTION
This fix #4.

Because our image base on nginx:stable-alpine, this image has realip_module https://github.com/nginxinc/docker-nginx/blob/e117bd83e9befe5582bc1da8f72248398fffa16c/stable/alpine/Dockerfile#L25